### PR TITLE
Feat/generic interceptor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,5 @@ FodyWeavers.xsd
 
 # Mac OS
 .DS_Store
+
+Migrations/

--- a/src/DotEmilu.EntityFrameworkCore/BaseAuditableEntity.cs
+++ b/src/DotEmilu.EntityFrameworkCore/BaseAuditableEntity.cs
@@ -6,7 +6,7 @@ namespace DotEmilu.EntityFrameworkCore;
 /// Although any struct type is allowed, using common types facilitates interoperability and performance.
 /// </summary>
 /// <typeparam name="TUserKey">Type of the audit user identifier.</typeparam>
-public interface IBaseAuditableEntity<TUserKey>
+public interface IBaseAuditableEntity<TUserKey> : IBaseEntity
     where TUserKey : struct
 {
     public DateTimeOffset Created { get; set; }
@@ -25,6 +25,7 @@ public interface IBaseAuditableEntity<TUserKey>
 public abstract class BaseAuditableEntity<TUserKey> : IBaseAuditableEntity<TUserKey>
     where TUserKey : struct
 {
+    public bool IsDeleted { get; set; }
     public DateTimeOffset Created { get; set; }
     public TUserKey CreatedBy { get; set; }
     public DateTimeOffset LastModified { get; set; }

--- a/src/DotEmilu.EntityFrameworkCore/BaseAuditableEntity.cs
+++ b/src/DotEmilu.EntityFrameworkCore/BaseAuditableEntity.cs
@@ -41,7 +41,6 @@ public abstract class BaseAuditableEntity<TUserKey> : IBaseAuditableEntity<TUser
 /// </summary>
 /// <typeparam name="TKey">The type of the primary key for the entity.</typeparam>
 /// <typeparam name="TUserKey">The type of the user identifier for audit tracking.</typeparam>
-
 public interface IBaseAuditableEntity<TKey, TUserKey> : IBaseEntity<TKey>, IBaseAuditableEntity<TUserKey>
     where TKey : struct
     where TUserKey : struct;

--- a/src/DotEmilu.EntityFrameworkCore/BaseAuditableEntityConfiguration.cs
+++ b/src/DotEmilu.EntityFrameworkCore/BaseAuditableEntityConfiguration.cs
@@ -35,6 +35,9 @@ public sealed class BaseAuditableEntityConfiguration<TBaseAuditableEntity, TUser
             .IsRequired(false);
 
         builder
+            .UseIsDeleted();
+
+        builder
             .ApplyMappingStrategy(strategy);
     }
 }

--- a/src/DotEmilu.EntityFrameworkCore/BaseEntity.cs
+++ b/src/DotEmilu.EntityFrameworkCore/BaseEntity.cs
@@ -15,11 +15,10 @@ public interface IBaseEntity
 /// Although any struct type is allowed, using common types facilitates interoperability and performance.
 /// </summary>
 /// <typeparam name="TKey">Type of the primary key.</typeparam>
-public interface IBaseEntity<TKey>
+public interface IBaseEntity<TKey> : IBaseEntity
     where TKey : struct
 {
     TKey Id { get; set; }
-    bool IsDeleted { get; set; }
 }
 
 /// <summary>

--- a/src/DotEmilu.EntityFrameworkCore/BaseEntity.cs
+++ b/src/DotEmilu.EntityFrameworkCore/BaseEntity.cs
@@ -1,6 +1,15 @@
 namespace DotEmilu.EntityFrameworkCore;
 
 /// <summary>
+/// Represents an entity with soft delete support.
+/// Indicates whether the entity is marked as deleted without being physically removed from the database.
+/// </summary>
+public interface IBaseEntity
+{
+    bool IsDeleted { get; set; }
+}
+
+/// <summary>
 /// Represents the type of the primary key for the entity.
 /// It is recommended to use numeric types (such as int, long) or Guid for efficient identifiers.
 /// Although any struct type is allowed, using common types facilitates interoperability and performance.

--- a/src/DotEmilu.EntityFrameworkCore/BaseEntityConfiguration.cs
+++ b/src/DotEmilu.EntityFrameworkCore/BaseEntityConfiguration.cs
@@ -16,22 +16,13 @@ public sealed class BaseEntityConfiguration<TBaseEntity, TKey>(MappingStrategy s
             .ValueGeneratedOnAdd();
 
         builder
-            .Property(s => s.IsDeleted)
-            .HasColumnOrder(1)
-            .HasDefaultValue(false)
-            .IsRequired();
+            .UseIsDeleted(order: 1);
 
         if (enableRowVersion)
             builder
                 .Property<byte[]>(nameof(Version))
                 .IsRowVersion()
                 .IsRequired();
-
-        builder
-            .HasQueryFilter(s => !s.IsDeleted);
-
-        builder
-            .HasIndex(s => s.IsDeleted);
 
         builder
             .ApplyMappingStrategy(strategy);

--- a/src/DotEmilu.EntityFrameworkCore/DiContainer.cs
+++ b/src/DotEmilu.EntityFrameworkCore/DiContainer.cs
@@ -1,14 +1,20 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace DotEmilu.EntityFrameworkCore;
 
 public static class DiContainer
 {
-    public static IServiceCollection AddDotEmiluInterceptors<TContextUser>(this IServiceCollection services)
-        where TContextUser : class, IContextUser
-        => services
-            .AddSingleton(TimeProvider.System)
-            .AddScoped<IContextUser, TContextUser>()
-            .AddScoped<ISaveChangesInterceptor, SoftDeleteInterceptor>()
-            .AddScoped<ISaveChangesInterceptor, AuditableEntityInterceptor>();
+    public static IServiceCollection AddSoftDeleteInterceptor(this IServiceCollection services)
+        => services.AddScoped<ISaveChangesInterceptor, SoftDeleteInterceptor>();
+
+    public static IServiceCollection AddAuditableEntityInterceptor<TContextUser, TUserKey>(
+        this IServiceCollection services)
+        where TContextUser : class, IContextUser<TUserKey>
+        where TUserKey : struct
+    {
+        services.TryAddSingleton(TimeProvider.System);
+        services.TryAddScoped<IContextUser<TUserKey>, TContextUser>();
+        return services.AddScoped<ISaveChangesInterceptor, AuditableEntityInterceptor<TUserKey>>();
+    }
 }

--- a/src/DotEmilu.EntityFrameworkCore/DiContainer.cs
+++ b/src/DotEmilu.EntityFrameworkCore/DiContainer.cs
@@ -17,4 +17,48 @@ public static class DiContainer
         services.TryAddScoped<IContextUser<TUserKey>, TContextUser>();
         return services.AddScoped<ISaveChangesInterceptor, AuditableEntityInterceptor<TUserKey>>();
     }
+
+    public static IServiceCollection AddAuditableEntityInterceptors(this IServiceCollection services, Assembly assembly)
+    {
+        services.TryAddSingleton(TimeProvider.System);
+
+        var groupedByUserKeyType = GetContextUserImplementations(assembly)
+            .Select(t => new
+            {
+                Implementation = t,
+                Interface = t.GetInterfaces().First(IsContextUserInterface),
+                UserKeyType = t.GetInterfaces().First(IsContextUserInterface).GetGenericArguments()[0]
+            })
+            .GroupBy(x => x.UserKeyType)
+            .ToList();
+
+        if (groupedByUserKeyType.Any(g => g.Count() > 1))
+        {
+            var duplicateKeys = string.Join(", ", groupedByUserKeyType
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key.Name));
+            throw new ArgumentException(
+                $"There are multiple implementations of IContextUser<T> for the following key types: {duplicateKeys}");
+        }
+
+        foreach (var group in groupedByUserKeyType)
+        {
+            var contextUser = group.First();
+            services.TryAddScoped(contextUser.Interface, contextUser.Implementation);
+            var userKeyType = group.Key;
+            var auditableInterceptorType = typeof(AuditableEntityInterceptor<>).MakeGenericType(userKeyType);
+            services.AddScoped(typeof(ISaveChangesInterceptor), auditableInterceptorType);
+        }
+
+        return services;
+
+        static IEnumerable<Type> GetContextUserImplementations(Assembly assembly)
+            => assembly
+                .GetTypes()
+                .Where(t => t is { IsAbstract: false, IsInterface: false } &&
+                            t.GetInterfaces().Any(IsContextUserInterface));
+
+        static bool IsContextUserInterface(Type i)
+            => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IContextUser<>);
+    }
 }

--- a/src/DotEmilu.EntityFrameworkCore/Extensions/EntityTypeBuilderExtensions.cs
+++ b/src/DotEmilu.EntityFrameworkCore/Extensions/EntityTypeBuilderExtensions.cs
@@ -19,4 +19,24 @@ public static class EntityTypeBuilderExtensions
                 break;
         }
     }
+
+    public static void UseIsDeleted<T>(this EntityTypeBuilder<T> builder, int order = 0)
+        where T : class, IBaseEntity
+    {
+        builder
+            .Property(s => s.IsDeleted)
+            .HasDefaultValue(false)
+            .IsRequired();
+
+        if (order != 0)
+            builder
+                .Property(s => s.IsDeleted)
+                .HasColumnOrder(order);
+
+        builder
+            .HasQueryFilter(s => !s.IsDeleted);
+
+        builder
+            .HasIndex(s => s.IsDeleted);
+    }
 }

--- a/src/DotEmilu.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/DotEmilu.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -20,6 +20,31 @@ public static class ModelBuilderExtensions
         return modelBuilder;
     }
 
+    public static ModelBuilder ApplyBaseEntityConfiguration(this ModelBuilder modelBuilder,
+        MappingStrategy strategy = MappingStrategy.Tpc, bool enableRowVersion = false, params Type[] keyTypes)
+    {
+        if (keyTypes.Any(type => !type.IsValueType))
+            throw new ArgumentException("All keyTypes must be value types (structs).", nameof(keyTypes));
+
+        foreach (var keyType in keyTypes)
+        {
+            var baseEntityGenericType = typeof(IBaseEntity<>).MakeGenericType(keyType);
+
+            foreach (var entityType in modelBuilder.Model
+                         .GetEntityTypes()
+                         .Where(e => baseEntityGenericType
+                             .IsAssignableFrom(e.ClrType) && !e.ClrType.IsAbstract))
+            {
+                var configType = typeof(BaseEntityConfiguration<,>)
+                    .MakeGenericType(entityType.ClrType, keyType);
+                var configInstance = Activator.CreateInstance(configType, strategy, enableRowVersion);
+                modelBuilder.ApplyConfiguration((dynamic)configInstance!);
+            }
+        }
+
+        return modelBuilder;
+    }
+
     public static ModelBuilder ApplyBaseAuditableEntityConfiguration<TUserKey>(this ModelBuilder modelBuilder,
         MappingStrategy strategy = MappingStrategy.Tpc)
         where TUserKey : struct
@@ -33,6 +58,31 @@ public static class ModelBuilderExtensions
                 .MakeGenericType(entityType.ClrType, typeof(TUserKey));
             var configInstance = Activator.CreateInstance(configType, strategy);
             modelBuilder.ApplyConfiguration((dynamic)configInstance!);
+        }
+
+        return modelBuilder;
+    }
+
+    public static ModelBuilder ApplyBaseAuditableEntityConfiguration(this ModelBuilder modelBuilder,
+        MappingStrategy strategy = MappingStrategy.Tpc, params Type[] userKeyTypes)
+    {
+        if (userKeyTypes.Any(type => !type.IsValueType))
+            throw new ArgumentException("All userKeyTypes must be value types (structs).", nameof(userKeyTypes));
+
+        foreach (var userKeyType in userKeyTypes)
+        {
+            var baseAuditableEntityGenericType = typeof(IBaseAuditableEntity<>).MakeGenericType(userKeyType);
+
+            foreach (var entityType in modelBuilder.Model
+                         .GetEntityTypes()
+                         .Where(e => baseAuditableEntityGenericType
+                             .IsAssignableFrom(e.ClrType) && !e.ClrType.IsAbstract))
+            {
+                var configType = typeof(BaseAuditableEntityConfiguration<,>)
+                    .MakeGenericType(entityType.ClrType, userKeyType);
+                var configInstance = Activator.CreateInstance(configType, strategy);
+                modelBuilder.ApplyConfiguration((dynamic)configInstance!);
+            }
         }
 
         return modelBuilder;

--- a/src/DotEmilu.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/DotEmilu.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -1,0 +1,40 @@
+namespace DotEmilu.EntityFrameworkCore.Extensions;
+
+public static class ModelBuilderExtensions
+{
+    public static ModelBuilder ApplyBaseEntityConfiguration<TKey>(this ModelBuilder modelBuilder,
+        MappingStrategy strategy = MappingStrategy.Tpc, bool enableRowVersion = false)
+        where TKey : struct
+    {
+        foreach (var entityType in modelBuilder.Model
+                     .GetEntityTypes()
+                     .Where(e => typeof(IBaseEntity<TKey>)
+                         .IsAssignableFrom(e.ClrType) && !e.ClrType.IsAbstract))
+        {
+            var configType = typeof(BaseEntityConfiguration<,>)
+                .MakeGenericType(entityType.ClrType, typeof(TKey));
+            var configInstance = Activator.CreateInstance(configType, strategy, enableRowVersion);
+            modelBuilder.ApplyConfiguration((dynamic)configInstance!);
+        }
+
+        return modelBuilder;
+    }
+
+    public static ModelBuilder ApplyBaseAuditableEntityConfiguration<TUserKey>(this ModelBuilder modelBuilder,
+        MappingStrategy strategy = MappingStrategy.Tpc)
+        where TUserKey : struct
+    {
+        foreach (var entityType in modelBuilder.Model
+                     .GetEntityTypes()
+                     .Where(e => typeof(IBaseAuditableEntity<TUserKey>)
+                         .IsAssignableFrom(e.ClrType) && !e.ClrType.IsAbstract))
+        {
+            var configType = typeof(BaseAuditableEntityConfiguration<,>)
+                .MakeGenericType(entityType.ClrType, typeof(TUserKey));
+            var configInstance = Activator.CreateInstance(configType, strategy);
+            modelBuilder.ApplyConfiguration((dynamic)configInstance!);
+        }
+
+        return modelBuilder;
+    }
+}

--- a/src/DotEmilu.EntityFrameworkCore/GlobalUsings.cs
+++ b/src/DotEmilu.EntityFrameworkCore/GlobalUsings.cs
@@ -1,5 +1,7 @@
 // Global using directives
 
+global using System.Reflection;
+global using DotEmilu.EntityFrameworkCore.Extensions;
 global using Microsoft.EntityFrameworkCore;
 global using Microsoft.EntityFrameworkCore.ChangeTracking;
 global using Microsoft.EntityFrameworkCore.Diagnostics;

--- a/src/DotEmilu.EntityFrameworkCore/IContextUser.cs
+++ b/src/DotEmilu.EntityFrameworkCore/IContextUser.cs
@@ -1,6 +1,7 @@
 namespace DotEmilu.EntityFrameworkCore;
 
-public interface IContextUser
+public interface IContextUser<out TUserKey>
+    where TUserKey : struct
 {
-    Guid Id { get; }
+    TUserKey Id { get; }
 }

--- a/src/DotEmilu.EntityFrameworkCore/SoftDeleteInterceptor.cs
+++ b/src/DotEmilu.EntityFrameworkCore/SoftDeleteInterceptor.cs
@@ -1,7 +1,6 @@
 namespace DotEmilu.EntityFrameworkCore;
 
-public sealed class SoftDeleteInterceptor<TKey> : SaveChangesInterceptor
-    where TKey : struct
+public sealed class SoftDeleteInterceptor : SaveChangesInterceptor
 {
     public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
     {
@@ -21,7 +20,7 @@ public sealed class SoftDeleteInterceptor<TKey> : SaveChangesInterceptor
     {
         if (context is null) return;
 
-        foreach (var entry in context.ChangeTracker.Entries<IBaseEntity<TKey>>())
+        foreach (var entry in context.ChangeTracker.Entries<IBaseEntity>())
         {
             if (entry.State != EntityState.Deleted) continue;
 

--- a/src/DotEmilu.EntityFrameworkCore/SoftDeleteInterceptor.cs
+++ b/src/DotEmilu.EntityFrameworkCore/SoftDeleteInterceptor.cs
@@ -1,6 +1,7 @@
 namespace DotEmilu.EntityFrameworkCore;
 
-public sealed class SoftDeleteInterceptor : SaveChangesInterceptor
+public sealed class SoftDeleteInterceptor<TKey> : SaveChangesInterceptor
+    where TKey : struct
 {
     public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
     {
@@ -20,7 +21,7 @@ public sealed class SoftDeleteInterceptor : SaveChangesInterceptor
     {
         if (context is null) return;
 
-        foreach (var entry in context.ChangeTracker.Entries<BaseEntity>())
+        foreach (var entry in context.ChangeTracker.Entries<IBaseEntity<TKey>>())
         {
             if (entry.State != EntityState.Deleted) continue;
 

--- a/tests/Example.SqlServer/ContextUser.cs
+++ b/tests/Example.SqlServer/ContextUser.cs
@@ -1,6 +1,6 @@
 namespace Example.SqlServer;
 
-public class ContextUser : IContextUser
+public class ContextUser : IContextUser<Guid>
 {
     public Guid Id => Guid.Parse("66931274-341d-41a0-0ec4-08dd5e9e0461");
 }

--- a/tests/Example.SqlServer/Entities/Song.cs
+++ b/tests/Example.SqlServer/Entities/Song.cs
@@ -1,6 +1,6 @@
 namespace Example.SqlServer.Entities;
 
-public class Song : BaseAuditableEntity<Guid>
+public class Song : BaseAuditableEntity<Guid, Guid>
 {
     public required string Name { get; set; }
 }

--- a/tests/Example.SqlServer/GlobalUsings.cs
+++ b/tests/Example.SqlServer/GlobalUsings.cs
@@ -1,5 +1,6 @@
 // Global using directives
 
+global using System.Reflection;
 global using DotEmilu.EntityFrameworkCore;
 global using Example.SqlServer;
 global using Example.SqlServer.Entities;

--- a/tests/Example.SqlServer/Program.cs
+++ b/tests/Example.SqlServer/Program.cs
@@ -1,6 +1,18 @@
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+builder.Services
+    .AddSoftDeleteInterceptor()
+    //.AddAuditableEntityInterceptor<ContextUser, Guid>()
+    .AddAuditableEntityInterceptors(Assembly.GetExecutingAssembly())
+    .AddDbContext<SqlServerContext>((sp, options) =>
+    {
+        options
+            .UseSqlServer(connectionString: builder.Configuration.GetSection("DefaultConnection").Get<string>())
+            .EnableDetailedErrors()
+            .EnableSensitiveDataLogging()
+            .AddInterceptors(sp.GetServices<ISaveChangesInterceptor>());
+    });
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -13,6 +25,16 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+app.MapGroup("api/person")
+    .WithTags("person")
+    .WithOpenApi()
+    .MapPerson();
+
+app.MapGroup("api/song")
+    .WithTags("song")
+    .WithOpenApi()
+    .MapSong();
 
 app.UseHttpsRedirection();
 

--- a/tests/Example.SqlServer/SqlServerContext.cs
+++ b/tests/Example.SqlServer/SqlServerContext.cs
@@ -1,0 +1,18 @@
+using DotEmilu.EntityFrameworkCore.Extensions;
+
+namespace Example.SqlServer;
+
+public class SqlServerContext(DbContextOptions<SqlServerContext> options) : DbContext(options)
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder
+            .ApplyBaseAuditableEntityConfiguration(Assembly.GetExecutingAssembly())
+            .ApplyBaseEntityConfiguration(Assembly.GetExecutingAssembly())
+            .ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
+    }
+
+    public DbSet<Person> Persons => Set<Person>();
+    public DbSet<Song> Songs => Set<Song>();
+}


### PR DESCRIPTION
# Soft Delete and Generic Support Improvements  

## What's New  
- Base entities now have an `IsDeleted` property.  
- New extensions to use the `IsDeleted` property in multiple configurations.  
- The soft delete interceptor now works with the base entity.  
- The auditable entity interceptor supports a generic user key.  
- Context user supports a generic ID type for better flexibility.  
- Dependency Injection (DI) extensions to register all services implementing specific interfaces.  
- New model builder extensions to register configurations by type or assembly.  

## Benefits  
- More flexible and customizable entity configurations.  
- Easier setup for dependency injection and interceptors.  
- Consistent handling of soft deletes across entities.  